### PR TITLE
support Linux

### DIFF
--- a/Sources/Dingbot/Dingbot.swift
+++ b/Sources/Dingbot/Dingbot.swift
@@ -2,7 +2,12 @@
 //  Created by iWw on 2022/1/26.
 //
 
+#if os(iOS) || os(macOS)
 import Foundation
+#elseif os(linux)
+import FoundationNetworking
+#endif
+
 import Crypto
 
 /// Encrypt string with key to hmacSHA256 and then to base64EncodedString

--- a/Sources/Dingbot/Dingbot.swift
+++ b/Sources/Dingbot/Dingbot.swift
@@ -2,10 +2,11 @@
 //  Created by iWw on 2022/1/26.
 //
 
-#if os(iOS) || os(macOS)
+#if (os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
 import Foundation
 #elseif os(Linux)
 import FoundationNetworking
+import Foundation
 #endif
 
 import Crypto

--- a/Sources/Dingbot/Dingbot.swift
+++ b/Sources/Dingbot/Dingbot.swift
@@ -28,7 +28,6 @@ fileprivate func hmacSHA256Base64String(string: String, key: String) -> String {
 public protocol DingbotMessage { func httpBody() -> Data? }
 
 // MARK: - Dingbot
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public struct Dingbot {
     private init() { }
     public static var shared = Dingbot()
@@ -125,7 +124,7 @@ public struct Dingbot {
         urlRequest.allHTTPHeaderFields = [
             "Content-Type": "application/json; charset=utf-8"
         ]
-        let result = try await URLSession.shared.data(for: urlRequest, delegate: nil)
+        let result = try await URLSession.shared.data(for: urlRequest)
         let _response = (result.1 as! HTTPURLResponse)
         return (result.0, _response)
     }

--- a/Sources/Dingbot/Dingbot.swift
+++ b/Sources/Dingbot/Dingbot.swift
@@ -4,7 +4,7 @@
 
 #if os(iOS) || os(macOS)
 import Foundation
-#elseif os(linux)
+#elseif os(Linux)
 import FoundationNetworking
 #endif
 

--- a/Sources/Dingbot/Dingbot.swift
+++ b/Sources/Dingbot/Dingbot.swift
@@ -9,6 +9,7 @@ import FoundationNetworking
 import Foundation
 #endif
 
+#if compiler(>=5.5) && canImport(_Concurrency)
 import Crypto
 
 /// Encrypt string with key to hmacSHA256 and then to base64EncodedString
@@ -27,6 +28,7 @@ fileprivate func hmacSHA256Base64String(string: String, key: String) -> String {
 public protocol DingbotMessage { func httpBody() -> Data? }
 
 // MARK: - Dingbot
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public struct Dingbot {
     private init() { }
     public static var shared = Dingbot()
@@ -123,9 +125,9 @@ public struct Dingbot {
         urlRequest.allHTTPHeaderFields = [
             "Content-Type": "application/json; charset=utf-8"
         ]
-        let (data, response) = try await URLSession.shared.data(for: urlRequest, delegate: nil)
-        let _response = (response as! HTTPURLResponse)
-        return (data, _response)
+        let result = try await URLSession.shared.data(for: urlRequest, delegate: nil)
+        let _response = (result.1 as! HTTPURLResponse)
+        return (result.0, _response)
     }
 }
 
@@ -235,3 +237,4 @@ public extension Dingbot {
         }
     }
 }
+#endif


### PR DESCRIPTION
- fix linux
- fix os(linux) to os(Linux)
- update
- update
- fix

support linux, but swift 5.5 ubuntu libraries does not contains async for URLSession.share.data(for: URLRequest)

so, waiting apple update.
